### PR TITLE
re-introduce websocket support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
 dependencies = [
  "axum-core 0.5.0",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -266,8 +267,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -456,6 +459,9 @@ name = "bytes"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "caseless"
@@ -634,7 +640,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "subtle",
  "time",
@@ -782,7 +788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -850,6 +856,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "deranged"
@@ -1322,7 +1334,7 @@ dependencies = [
  "lasso",
  "once_cell",
  "phf",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1924,7 +1936,7 @@ dependencies = [
  "parking_lot",
  "path-tree",
  "prettytable-rs",
- "rand",
+ "rand 0.8.5",
  "reedline",
  "regex",
  "reqwest",
@@ -2364,7 +2376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2531,7 +2543,7 @@ checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
  "getrandom 0.2.15",
- "rand",
+ "rand 0.8.5",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2573,8 +2585,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2584,7 +2606,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2594,6 +2626,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -3014,6 +3055,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3439,6 +3491,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3664,6 +3728,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.1",
+ "sha1",
+ "thiserror 2.0.11",
+ "utf-8",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3746,6 +3827,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ codegen-units = 1
 
 [dependencies]
 async-tempfile = "0.6.0"
-axum = { version = "0.8.1", features = ["http2"] }
+axum = { version = "0.8.1", features = ["http2", "ws"] }
 base64 = "0.22.1"
-bytes = "1.9.0"
+bytes = { version = "1.9.0", features = ["serde"] }
 clap = { version = "4.5.23", features = ["derive", "env"] }
 color-eyre = "0.6.3"
 colored_json = "5.0.0"

--- a/files/templates/layout.html
+++ b/files/templates/layout.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="/assets/pico.css">
     {% block extra_css %}{% endblock %}
     <script src="/assets/htmx.min.js"></script>
+    <script src="/assets/htmx-ext-ws.min.js"></script>
     {% block extra_head_js %}{% endblock %}
 </head>
 

--- a/src/command/new.rs
+++ b/src/command/new.rs
@@ -108,15 +108,15 @@ impl New {
                 NewError::WriteFile(assets_dir.join("pico.css").to_string_lossy().to_string(), e)
             })?;
 
-        println!("writing htmx.min.js");
-        tokio::fs::write(assets_dir.join("htmx.min.js"), HTMX_JS)
-            .await
-            .map_err(|e| {
-                NewError::WriteFile(
-                    assets_dir.join("htmx.min.js").to_string_lossy().to_string(),
-                    e,
-                )
-            })?;
+        let htmx_files = ["htmx.min.js", "htmx-ext-ws.min.js"];
+        for htmx_file in htmx_files {
+            println!("writing {htmx_file}");
+            tokio::fs::write(assets_dir.join(htmx_file), HTMX_JS)
+                .await
+                .map_err(|e| {
+                    NewError::WriteFile(assets_dir.join(htmx_file).to_string_lossy().to_string(), e)
+                })?;
+        }
 
         for file in Files::iter() {
             let path = self.directory.join(file.as_ref());

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,10 @@ use parking_lot::Mutex;
 use reedline::ExternalPrinter;
 use std::{io::IsTerminal, sync::Arc, time::Duration};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
-use tracing_subscriber::{fmt::MakeWriter, EnvFilter};
+use tracing_subscriber::{
+    fmt::{format::FmtSpan, MakeWriter},
+    EnvFilter,
+};
 
 use command::Args;
 
@@ -124,7 +127,7 @@ fn init_tracing_subscriber(output: Output) {
         .with_thread_names(false)
         .with_file(false)
         .with_line_number(false)
-        // .with_span_events(FmtSpan::ENTER | FmtSpan::EXIT)
+        .with_span_events(FmtSpan::ENTER | FmtSpan::EXIT)
         .with_env_filter(filter)
         .with_ansi(is_terminal)
         .compact()

--- a/src/prelude.lua
+++ b/src/prelude.lua
@@ -119,3 +119,10 @@ function drop(n, iter, state, initial)
         return val
     end, state, var
 end
+
+
+function printf(fmt, ...)
+    local args = {...}
+    local str = string.format(fmt, table.unpack(args))
+    print(str)
+end

--- a/src/runtime/http.rs
+++ b/src/runtime/http.rs
@@ -1,3 +1,5 @@
+pub mod websocket;
+
 use axum::{
     body::{to_bytes, Body},
     http::{HeaderMap, HeaderName, HeaderValue},
@@ -12,6 +14,8 @@ use rusqlite::OptionalExtension;
 use std::{ops::Deref, sync::Arc};
 
 use crate::database::Database;
+
+pub use websocket::LuaWebSocket;
 
 const FETCH_CLIENT: &str = "fetch_client";
 const REQUEST_MT: &str = "request_mt";

--- a/src/runtime/http/websocket.rs
+++ b/src/runtime/http/websocket.rs
@@ -1,0 +1,154 @@
+use axum::extract::ws::{Message, Utf8Bytes, WebSocket};
+use futures_util::{
+    stream::{SplitSink, SplitStream},
+    SinkExt, StreamExt,
+};
+use mlua::prelude::*;
+use tokio::sync::Mutex;
+
+pub struct LuaMessage(Message);
+
+pub struct LuaWebSocket {
+    sender: Mutex<SplitSink<WebSocket, Message>>,
+    receiver: Mutex<SplitStream<WebSocket>>,
+}
+
+impl LuaWebSocket {
+    pub fn new(ws: WebSocket) -> Self {
+        let (sender, receiver) = ws.split();
+
+        LuaWebSocket {
+            sender: Mutex::new(sender),
+            receiver: Mutex::new(receiver),
+        }
+    }
+
+    async fn send(&self, msg: LuaMessage) -> Result<(), LuaError> {
+        let mut sender = self.sender.lock().await;
+        sender.send(msg.into()).await.into_lua_err()
+    }
+
+    async fn recv(&self) -> Result<Option<LuaMessage>, LuaError> {
+        let mut receiver = self.receiver.lock().await;
+        let resp = receiver.next().await.transpose().into_lua_err()?;
+        Ok(resp.map(LuaMessage))
+    }
+}
+
+impl From<LuaMessage> for Message {
+    fn from(val: LuaMessage) -> Self {
+        val.0
+    }
+}
+
+impl From<Message> for LuaMessage {
+    fn from(val: Message) -> Self {
+        LuaMessage(val)
+    }
+}
+
+impl LuaUserData for LuaWebSocket {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        methods.add_async_method("send", |lua, this, msg: LuaValue| async move {
+            let msg = LuaMessage::from_lua(msg, &lua)?;
+            this.send(msg).await
+        });
+        methods.add_async_method("recv", |_lua, this, ()| async move { this.recv().await });
+    }
+
+    /// ws.binary is a shortcut for { type = "binary", data = ... }
+    /// same for ping and pong.
+    fn add_fields<F: LuaUserDataFields<Self>>(fields: &mut F) {
+        add_lua_message_field("binary", fields);
+        add_lua_message_field("ping", fields);
+        add_lua_message_field("pong", fields);
+    }
+}
+
+fn add_lua_message_field<F>(name: &'static str, fields: &mut F)
+where
+    F: LuaUserDataFields<LuaWebSocket>,
+{
+    fields.add_field_function_get(name, move |lua, _| {
+        lua.create_function(move |lua, data: LuaString| {
+            let table = lua.create_table()?;
+            table.set("type", name)?;
+            table.set("data", data)?;
+            Ok(table)
+        })
+    });
+}
+
+fn lua_message(lua: &Lua, ws_type: &str, ws_data: &[u8]) -> LuaResult<LuaValue> {
+    let table = lua.create_table()?;
+    table.set("type", ws_type)?;
+    table.set("data", lua.create_string(ws_data)?)?;
+    Ok(LuaValue::Table(table))
+}
+
+impl IntoLua for LuaMessage {
+    fn into_lua(self, lua: &Lua) -> LuaResult<LuaValue> {
+        let LuaMessage(msg) = self;
+
+        let value = match msg {
+            Message::Text(utf8_bytes) => {
+                LuaValue::String(lua.create_string(utf8_bytes.as_bytes())?)
+            }
+            Message::Binary(bytes) => lua_message(lua, "binary", &bytes)?,
+            Message::Ping(bytes) => lua_message(lua, "ping", &bytes)?,
+            Message::Pong(bytes) => lua_message(lua, "pong", &bytes)?,
+            Message::Close(_) => return Ok(LuaValue::Nil),
+        };
+
+        Ok(value)
+    }
+}
+
+impl FromLua for LuaMessage {
+    fn from_lua(value: LuaValue, _lua: &Lua) -> LuaResult<Self> {
+        match value {
+            LuaValue::String(s) => {
+                let msg = Message::Text(Utf8Bytes::from(&*s.to_str()?));
+                Ok(msg.into())
+            }
+            LuaValue::Table(table) => {
+                let msg_type: String = table.get("type")?;
+                let data: String = table.get("data")?;
+
+                match msg_type.as_str() {
+                    "binary" => Ok(LuaMessage(Message::Binary(data.into()))),
+                    "ping" => Ok(LuaMessage(Message::Ping(data.into()))),
+                    "pong" => Ok(LuaMessage(Message::Pong(data.into()))),
+                    _ => Err(LuaError::RuntimeError("Invalid message type".into())),
+                }
+            }
+            _ => Err(LuaError::RuntimeError("Expected a table".into())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::ws::Message;
+
+    #[test]
+    fn test_lua_message_conversion() {
+        let lua = Lua::new();
+        let message = Message::Text("Hello, World!".into());
+        let lua_message: LuaMessage = message.into();
+
+        let lua_value = lua_message.into_lua(&lua).unwrap();
+        assert!(lua_value.is_table());
+
+        let converted_message: LuaMessage = LuaMessage::from_lua(lua_value, &lua).unwrap();
+        assert_eq!(converted_message.0, Message::Text("Hello, World!".into()));
+
+        let code = r#"
+            msg = { type = "binary", data = "stuff" }
+        "#;
+        lua.load(code).exec().unwrap();
+        let msg = lua.globals().get::<LuaMessage>("msg").unwrap();
+        assert_eq!(msg.0, Message::Binary("stuff".into()))
+    }
+}

--- a/vendor/htmx-ext-ws.min.js
+++ b/vendor/htmx-ext-ws.min.js
@@ -1,0 +1,471 @@
+/*
+WebSockets Extension
+============================
+This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md for usage instructions.
+*/
+
+(function() {
+  /** @type {import("../htmx").HtmxInternalApi} */
+  var api
+
+  htmx.defineExtension('ws', {
+
+    /**
+     * init is called once, when this extension is first registered.
+     * @param {import("../htmx").HtmxInternalApi} apiRef
+     */
+    init: function(apiRef) {
+      // Store reference to internal API
+      api = apiRef
+
+      // Default function for creating new EventSource objects
+      if (!htmx.createWebSocket) {
+        htmx.createWebSocket = createWebSocket
+      }
+
+      // Default setting for reconnect delay
+      if (!htmx.config.wsReconnectDelay) {
+        htmx.config.wsReconnectDelay = 'full-jitter'
+      }
+    },
+
+    /**
+     * onEvent handles all events passed to this extension.
+     *
+     * @param {string} name
+     * @param {Event} evt
+     */
+    onEvent: function(name, evt) {
+      var parent = evt.target || evt.detail.elt
+      switch (name) {
+        // Try to close the socket when elements are removed
+        case 'htmx:beforeCleanupElement':
+
+          var internalData = api.getInternalData(parent)
+
+          if (internalData.webSocket) {
+            internalData.webSocket.close()
+          }
+          return
+
+          // Try to create websockets when elements are processed
+        case 'htmx:beforeProcessNode':
+
+          forEach(queryAttributeOnThisOrChildren(parent, 'ws-connect'), function(child) {
+            ensureWebSocket(child)
+          })
+          forEach(queryAttributeOnThisOrChildren(parent, 'ws-send'), function(child) {
+            ensureWebSocketSend(child)
+          })
+      }
+    }
+  })
+
+  function splitOnWhitespace(trigger) {
+    return trigger.trim().split(/\s+/)
+  }
+
+  function getLegacyWebsocketURL(elt) {
+    var legacySSEValue = api.getAttributeValue(elt, 'hx-ws')
+    if (legacySSEValue) {
+      var values = splitOnWhitespace(legacySSEValue)
+      for (var i = 0; i < values.length; i++) {
+        var value = values[i].split(/:(.+)/)
+        if (value[0] === 'connect') {
+          return value[1]
+        }
+      }
+    }
+  }
+
+  /**
+   * ensureWebSocket creates a new WebSocket on the designated element, using
+   * the element's "ws-connect" attribute.
+   * @param {HTMLElement} socketElt
+   * @returns
+   */
+  function ensureWebSocket(socketElt) {
+    // If the element containing the WebSocket connection no longer exists, then
+    // do not connect/reconnect the WebSocket.
+    if (!api.bodyContains(socketElt)) {
+      return
+    }
+
+    // Get the source straight from the element's value
+    var wssSource = api.getAttributeValue(socketElt, 'ws-connect')
+
+    if (wssSource == null || wssSource === '') {
+      var legacySource = getLegacyWebsocketURL(socketElt)
+      if (legacySource == null) {
+        return
+      } else {
+        wssSource = legacySource
+      }
+    }
+
+    // Guarantee that the wssSource value is a fully qualified URL
+    if (wssSource.indexOf('/') === 0) {
+      var base_part = location.hostname + (location.port ? ':' + location.port : '')
+      if (location.protocol === 'https:') {
+        wssSource = 'wss://' + base_part + wssSource
+      } else if (location.protocol === 'http:') {
+        wssSource = 'ws://' + base_part + wssSource
+      }
+    }
+
+    var socketWrapper = createWebsocketWrapper(socketElt, function() {
+      return htmx.createWebSocket(wssSource)
+    })
+
+    socketWrapper.addEventListener('message', function(event) {
+      if (maybeCloseWebSocketSource(socketElt)) {
+        return
+      }
+
+      var response = event.data
+      if (!api.triggerEvent(socketElt, 'htmx:wsBeforeMessage', {
+        message: response,
+        socketWrapper: socketWrapper.publicInterface
+      })) {
+        return
+      }
+
+      api.withExtensions(socketElt, function(extension) {
+        response = extension.transformResponse(response, null, socketElt)
+      })
+
+      var settleInfo = api.makeSettleInfo(socketElt)
+      var fragment = api.makeFragment(response)
+
+      if (fragment.children.length) {
+        var children = Array.from(fragment.children)
+        for (var i = 0; i < children.length; i++) {
+          api.oobSwap(api.getAttributeValue(children[i], 'hx-swap-oob') || 'true', children[i], settleInfo)
+        }
+      }
+
+      api.settleImmediately(settleInfo.tasks)
+      api.triggerEvent(socketElt, 'htmx:wsAfterMessage', { message: response, socketWrapper: socketWrapper.publicInterface })
+    })
+
+    // Put the WebSocket into the HTML Element's custom data.
+    api.getInternalData(socketElt).webSocket = socketWrapper
+  }
+
+  /**
+   * @typedef {Object} WebSocketWrapper
+   * @property {WebSocket} socket
+   * @property {Array<{message: string, sendElt: Element}>} messageQueue
+   * @property {number} retryCount
+   * @property {(message: string, sendElt: Element) => void} sendImmediately sendImmediately sends message regardless of websocket connection state
+   * @property {(message: string, sendElt: Element) => void} send
+   * @property {(event: string, handler: Function) => void} addEventListener
+   * @property {() => void} handleQueuedMessages
+   * @property {() => void} init
+   * @property {() => void} close
+   */
+  /**
+   *
+   * @param socketElt
+   * @param socketFunc
+   * @returns {WebSocketWrapper}
+   */
+  function createWebsocketWrapper(socketElt, socketFunc) {
+    var wrapper = {
+      socket: null,
+      messageQueue: [],
+      retryCount: 0,
+
+      /** @type {Object<string, Function[]>} */
+      events: {},
+
+      addEventListener: function(event, handler) {
+        if (this.socket) {
+          this.socket.addEventListener(event, handler)
+        }
+
+        if (!this.events[event]) {
+          this.events[event] = []
+        }
+
+        this.events[event].push(handler)
+      },
+
+      sendImmediately: function(message, sendElt) {
+        if (!this.socket) {
+          api.triggerErrorEvent()
+        }
+        if (!sendElt || api.triggerEvent(sendElt, 'htmx:wsBeforeSend', {
+          message,
+          socketWrapper: this.publicInterface
+        })) {
+          this.socket.send(message)
+          sendElt && api.triggerEvent(sendElt, 'htmx:wsAfterSend', {
+            message,
+            socketWrapper: this.publicInterface
+          })
+        }
+      },
+
+      send: function(message, sendElt) {
+        if (this.socket.readyState !== this.socket.OPEN) {
+          this.messageQueue.push({ message, sendElt })
+        } else {
+          this.sendImmediately(message, sendElt)
+        }
+      },
+
+      handleQueuedMessages: function() {
+        while (this.messageQueue.length > 0) {
+          var queuedItem = this.messageQueue[0]
+          if (this.socket.readyState === this.socket.OPEN) {
+            this.sendImmediately(queuedItem.message, queuedItem.sendElt)
+            this.messageQueue.shift()
+          } else {
+            break
+          }
+        }
+      },
+
+      init: function() {
+        if (this.socket && this.socket.readyState === this.socket.OPEN) {
+          // Close discarded socket
+          this.socket.close()
+        }
+
+        // Create a new WebSocket and event handlers
+        /** @type {WebSocket} */
+        var socket = socketFunc()
+
+        // The event.type detail is added for interface conformance with the
+        // other two lifecycle events (open and close) so a single handler method
+        // can handle them polymorphically, if required.
+        api.triggerEvent(socketElt, 'htmx:wsConnecting', { event: { type: 'connecting' } })
+
+        this.socket = socket
+
+        socket.onopen = function(e) {
+          wrapper.retryCount = 0
+          api.triggerEvent(socketElt, 'htmx:wsOpen', { event: e, socketWrapper: wrapper.publicInterface })
+          wrapper.handleQueuedMessages()
+        }
+
+        socket.onclose = function(e) {
+          // If socket should not be connected, stop further attempts to establish connection
+          // If Abnormal Closure/Service Restart/Try Again Later, then set a timer to reconnect after a pause.
+          if (!maybeCloseWebSocketSource(socketElt) && [1006, 1012, 1013].indexOf(e.code) >= 0) {
+            var delay = getWebSocketReconnectDelay(wrapper.retryCount)
+            setTimeout(function() {
+              wrapper.retryCount += 1
+              wrapper.init()
+            }, delay)
+          }
+
+          // Notify client code that connection has been closed. Client code can inspect `event` field
+          // to determine whether closure has been valid or abnormal
+          api.triggerEvent(socketElt, 'htmx:wsClose', { event: e, socketWrapper: wrapper.publicInterface })
+        }
+
+        socket.onerror = function(e) {
+          api.triggerErrorEvent(socketElt, 'htmx:wsError', { error: e, socketWrapper: wrapper })
+          maybeCloseWebSocketSource(socketElt)
+        }
+
+        var events = this.events
+        Object.keys(events).forEach(function(k) {
+          events[k].forEach(function(e) {
+            socket.addEventListener(k, e)
+          })
+        })
+      },
+
+      close: function() {
+        this.socket.close()
+      }
+    }
+
+    wrapper.init()
+
+    wrapper.publicInterface = {
+      send: wrapper.send.bind(wrapper),
+      sendImmediately: wrapper.sendImmediately.bind(wrapper),
+      queue: wrapper.messageQueue
+    }
+
+    return wrapper
+  }
+
+  /**
+   * ensureWebSocketSend attaches trigger handles to elements with
+   * "ws-send" attribute
+   * @param {HTMLElement} elt
+   */
+  function ensureWebSocketSend(elt) {
+    var legacyAttribute = api.getAttributeValue(elt, 'hx-ws')
+    if (legacyAttribute && legacyAttribute !== 'send') {
+      return
+    }
+
+    var webSocketParent = api.getClosestMatch(elt, hasWebSocket)
+    processWebSocketSend(webSocketParent, elt)
+  }
+
+  /**
+   * hasWebSocket function checks if a node has webSocket instance attached
+   * @param {HTMLElement} node
+   * @returns {boolean}
+   */
+  function hasWebSocket(node) {
+    return api.getInternalData(node).webSocket != null
+  }
+
+  /**
+   * processWebSocketSend adds event listeners to the <form> element so that
+   * messages can be sent to the WebSocket server when the form is submitted.
+   * @param {HTMLElement} socketElt
+   * @param {HTMLElement} sendElt
+   */
+  function processWebSocketSend(socketElt, sendElt) {
+    var nodeData = api.getInternalData(sendElt)
+    var triggerSpecs = api.getTriggerSpecs(sendElt)
+    triggerSpecs.forEach(function(ts) {
+      api.addTriggerHandler(sendElt, ts, nodeData, function(elt, evt) {
+        if (maybeCloseWebSocketSource(socketElt)) {
+          return
+        }
+
+        /** @type {WebSocketWrapper} */
+        var socketWrapper = api.getInternalData(socketElt).webSocket
+        var headers = api.getHeaders(sendElt, api.getTarget(sendElt))
+        var results = api.getInputValues(sendElt, 'post')
+        var errors = results.errors
+        var rawParameters = Object.assign({}, results.values)
+        var expressionVars = api.getExpressionVars(sendElt)
+        var allParameters = api.mergeObjects(rawParameters, expressionVars)
+        var filteredParameters = api.filterValues(allParameters, sendElt)
+
+        var sendConfig = {
+          parameters: filteredParameters,
+          unfilteredParameters: allParameters,
+          headers,
+          errors,
+
+          triggeringEvent: evt,
+          messageBody: undefined,
+          socketWrapper: socketWrapper.publicInterface
+        }
+
+        if (!api.triggerEvent(elt, 'htmx:wsConfigSend', sendConfig)) {
+          return
+        }
+
+        if (errors && errors.length > 0) {
+          api.triggerEvent(elt, 'htmx:validation:halted', errors)
+          return
+        }
+
+        var body = sendConfig.messageBody
+        if (body === undefined) {
+          var toSend = Object.assign({}, sendConfig.parameters)
+          if (sendConfig.headers) { toSend.HEADERS = headers }
+          body = JSON.stringify(toSend)
+        }
+
+        socketWrapper.send(body, elt)
+
+        if (evt && api.shouldCancel(evt, elt)) {
+          evt.preventDefault()
+        }
+      })
+    })
+  }
+
+  /**
+   * getWebSocketReconnectDelay is the default easing function for WebSocket reconnects.
+   * @param {number} retryCount // The number of retries that have already taken place
+   * @returns {number}
+   */
+  function getWebSocketReconnectDelay(retryCount) {
+    /** @type {"full-jitter" | ((retryCount:number) => number)} */
+    var delay = htmx.config.wsReconnectDelay
+    if (typeof delay === 'function') {
+      return delay(retryCount)
+    }
+    if (delay === 'full-jitter') {
+      var exp = Math.min(retryCount, 6)
+      var maxDelay = 1000 * Math.pow(2, exp)
+      return maxDelay * Math.random()
+    }
+
+    logError('htmx.config.wsReconnectDelay must either be a function or the string "full-jitter"')
+  }
+
+  /**
+   * maybeCloseWebSocketSource checks to the if the element that created the WebSocket
+   * still exists in the DOM.  If NOT, then the WebSocket is closed and this function
+   * returns TRUE.  If the element DOES EXIST, then no action is taken, and this function
+   * returns FALSE.
+   *
+   * @param {*} elt
+   * @returns
+   */
+  function maybeCloseWebSocketSource(elt) {
+    if (!api.bodyContains(elt)) {
+      var internalData = api.getInternalData(elt)
+      if (internalData.webSocket) {
+        internalData.webSocket.close()
+        return true
+      }
+      return false
+    }
+    return false
+  }
+
+  /**
+   * createWebSocket is the default method for creating new WebSocket objects.
+   * it is hoisted into htmx.createWebSocket to be overridden by the user, if needed.
+   *
+   * @param {string} url
+   * @returns WebSocket
+   */
+  function createWebSocket(url) {
+    var sock = new WebSocket(url, [])
+    sock.binaryType = htmx.config.wsBinaryType
+    return sock
+  }
+
+  /**
+   * queryAttributeOnThisOrChildren returns all nodes that contain the requested attributeName, INCLUDING THE PROVIDED ROOT ELEMENT.
+   *
+   * @param {HTMLElement} elt
+   * @param {string} attributeName
+   */
+  function queryAttributeOnThisOrChildren(elt, attributeName) {
+    var result = []
+
+    // If the parent element also contains the requested attribute, then add it to the results too.
+    if (api.hasAttribute(elt, attributeName) || api.hasAttribute(elt, 'hx-ws')) {
+      result.push(elt)
+    }
+
+    // Search all child nodes that match the requested attribute
+    elt.querySelectorAll('[' + attributeName + '], [data-' + attributeName + '], [data-hx-ws], [hx-ws]').forEach(function(node) {
+      result.push(node)
+    })
+
+    return result
+  }
+
+  /**
+   * @template T
+   * @param {T[]} arr
+   * @param {(T) => void} func
+   */
+  function forEach(arr, func) {
+    if (arr) {
+      for (var i = 0; i < arr.length; i++) {
+        func(arr[i])
+      }
+    }
+  }
+})()


### PR DESCRIPTION
This PR carefully re-introduces an API for WebSockets. 

Key points:

- by default, websocket messages are encoded to and from lua strings.
- binary messages are supported in the form of `{ type = "binary", data = "..." }` and there's a convenient function on the websocket object for this: `ws.binary "..."`
- The userdata wrapper around WebSocket splits it into a sink and stream, and each of those is accessed with a tokio mutex to avoid the deadlocks inherent in the previous implementation
- preliminary support for for htmx-ws has been added, though I haven't found it to be working yet in my limited testing.