### PR TITLE
add support for mdns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "serde",
  "signal-hook",
  "signal-hook-mio",
@@ -1094,7 +1094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.52.0",
 ]
 
@@ -1127,6 +1127,17 @@ checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.3",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -1256,6 +1267,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
+dependencies = [
+ "rustix 1.0.7",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1693,6 +1714,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ignore"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,10 +1953,12 @@ dependencies = [
  "enable-ansi-support",
  "eyre",
  "futures-util",
+ "gethostname",
  "grass",
  "http",
  "ignore",
  "indexmap",
+ "mdns-sd",
  "mimalloc",
  "minijinja",
  "mlua",
@@ -1976,6 +2009,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -2044,6 +2083,20 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "mdns-sd"
+version = "0.13.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a61a86e69b0d6f1ace38f9f51e1c03c2d1b60cc16d3436ee9f036945344b0a75"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket2",
+]
 
 [[package]]
 name = "memchr"
@@ -2871,7 +2924,20 @@ dependencies = [
  "bitflags 2.8.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.8.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -3181,6 +3247,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3320,7 +3395,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -3341,7 +3416,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -4021,7 +4096,7 @@ checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
 dependencies = [
  "either",
  "env_home",
- "rustix",
+ "rustix 0.38.44",
  "winsafe",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,12 @@ crossbeam-channel = "0.5.15"
 dirs = "6.0.0"
 eyre = "0.6.12"
 futures-util = { version = "0.3.31", features = ["sink"] }
+gethostname = "1.0.2"
 grass = "0.13.4"
 http = "1.2.0"
 ignore = "0.4.23"
 indexmap = { version = "2.7.0", features = ["serde"] }
+mdns-sd = "0.13.9"
 mimalloc = "0.1.43"
 minijinja = { version = "2.5.0", features = ["loader", "json", "preserve_order"] }
 mlua = { version = "0.10.2", features = ["luajit52", "serialize", "send", "async", "vendored"] }

--- a/src/runtime/mdns.rs
+++ b/src/runtime/mdns.rs
@@ -1,0 +1,217 @@
+use std::{borrow::Cow, collections::HashMap, time::Duration};
+
+use mdns_sd::{Receiver, ResolvedService, ServiceDaemon, ServiceEvent, ServiceInfo};
+use mlua::prelude::*;
+use serde::{ser::SerializeMap, Deserialize, Serialize};
+
+use super::ToLuaArray;
+
+static MDNS_SERVICE_DAEMON: &str = "mdns.service_daemon";
+
+pub fn register(lua: &Lua) -> LuaResult<()> {
+    let globals = lua.globals();
+    let daemon = LuaServiceDaemon(ServiceDaemon::new().into_lua_err()?);
+    lua.set_named_registry_value(MDNS_SERVICE_DAEMON, daemon)?;
+
+    let mdns = lua.create_table()?;
+    mdns.set("browse", lua.create_async_function(mdns_browse)?)?;
+    mdns.set("register", lua.create_function(mdns_register)?)?;
+    mdns.set("stop_browse", lua.create_function(mdns_stop_browse)?)?;
+    mdns.set("service_info", lua.create_function(mdns_service_info)?)?;
+    globals.set("mdns", mdns)?;
+
+    Ok(())
+}
+
+struct LuaServiceDaemon(ServiceDaemon);
+
+impl LuaUserData for LuaServiceDaemon {}
+
+#[derive(Debug, Clone)]
+pub struct LuaServiceInfo(ServiceInfo);
+
+impl Serialize for LuaServiceInfo {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let service_info = &self.0;
+        let mut map = serializer.serialize_map(Some(6))?;
+        map.serialize_entry("type", service_info.get_type())?;
+        map.serialize_entry("subtype", &service_info.get_subtype())?;
+        map.serialize_entry("fullname", service_info.get_fullname())?;
+        map.serialize_entry("hostname", service_info.get_hostname())?;
+        map.serialize_entry("port", &service_info.get_port())?;
+        map.serialize_entry("addresses", &service_info.get_addresses())?;
+        map.end()
+    }
+}
+
+impl LuaUserData for LuaServiceInfo {
+    fn add_fields<F: LuaUserDataFields<Self>>(fields: &mut F) {
+        fields.add_field_method_get("type", |lua, this| {
+            let service_type = this.0.get_type();
+            lua.create_string(service_type)
+        });
+        fields.add_field_method_get("subtype", |_lua, this| {
+            let subtype = this.0.get_subtype().clone();
+            Ok(subtype)
+        });
+        fields.add_field_method_get("fullname", |lua, this| {
+            let fullname = this.0.get_fullname();
+            lua.create_string(fullname)
+        });
+        fields.add_field_method_get("hostname", |lua, this| {
+            let hostname = this.0.get_hostname();
+            lua.create_string(hostname)
+        });
+        fields.add_field_method_get("port", |_lua, this| {
+            let port = this.0.get_port();
+            Ok(port)
+        });
+        fields.add_field_method_get("addresses", |lua, this| {
+            let addresses = this.0.get_addresses();
+            addresses
+                .into_iter()
+                .map(ToString::to_string)
+                .to_lua_array(lua)
+        });
+    }
+}
+
+fn get_service_daemon(lua: &Lua) -> LuaResult<ServiceDaemon> {
+    let daemon = lua.named_registry_value::<LuaAnyUserData>(MDNS_SERVICE_DAEMON)?;
+    let daemon = daemon
+        .borrow::<LuaServiceDaemon>()
+        .map_err(|e| LuaError::RuntimeError(format!("Failed to borrow daemon: {}", e)))?;
+    Ok(daemon.0.clone())
+}
+
+async fn mdns_browse(lua: Lua, (service_type, callbacks): (String, LuaTable)) -> LuaResult<()> {
+    let daemon = get_service_daemon(&lua)?;
+    let receiver = daemon.browse(&service_type).into_lua_err()?;
+
+    let callbacks = Callbacks::new(callbacks)?;
+
+    tokio::spawn(async move {
+        while let Ok(event) = receiver.recv_async().await {
+            if let Err(err) = process_event(&lua, event, &callbacks).await {
+                tracing::error!("error processing mdns.browse event: {}", err);
+            }
+        }
+    });
+
+    Ok(())
+}
+
+fn mdns_register(lua: &Lua, service_info: LuaAnyUserData) -> LuaResult<()> {
+    let daemon = get_service_daemon(&lua)?;
+    let LuaServiceInfo(service_info) = service_info.borrow::<LuaServiceInfo>()?.clone();
+
+    daemon.register(service_info).into_lua_err()
+}
+
+pub struct Callbacks {
+    search_started: Option<LuaFunction>,
+    service_found: Option<LuaFunction>,
+    service_resolved: Option<LuaFunction>,
+    service_removed: Option<LuaFunction>,
+    search_stopped: Option<LuaFunction>,
+}
+
+impl Callbacks {
+    fn new(table: LuaTable) -> LuaResult<Self> {
+        let search_started: Option<LuaFunction> = table.get("search_started")?;
+        let service_found: Option<LuaFunction> = table.get("service_found")?;
+        let service_resolved: Option<LuaFunction> = table.get("service_resolved")?;
+        let service_removed: Option<LuaFunction> = table.get("service_removed")?;
+        let search_stopped: Option<LuaFunction> = table.get("search_stopped")?;
+        if search_started.is_none()
+            && service_found.is_none()
+            && service_resolved.is_none()
+            && service_removed.is_none()
+            && search_stopped.is_none()
+        {
+            return Err(LuaError::RuntimeError(
+                "at least one of search_started, service_found, service_resolved, service_removed, or search_stopped must be provided".to_string()
+            ));
+        }
+
+        Ok(Self {
+            search_started,
+            service_found,
+            service_resolved,
+            service_removed,
+            search_stopped,
+        })
+    }
+}
+
+async fn process_event(lua: &Lua, event: ServiceEvent, callbacks: &Callbacks) -> LuaResult<()> {
+    match event {
+        ServiceEvent::SearchStarted(service_type) => {
+            if let Some(ref callback) = callbacks.search_started {
+                callback.call_async::<()>((service_type,)).await?;
+            }
+        }
+        ServiceEvent::ServiceFound(service_type, fullname) => {
+            if let Some(ref callback) = callbacks.service_found {
+                callback.call_async::<()>((service_type, fullname)).await?;
+            }
+        }
+        ServiceEvent::ServiceResolved(service_info) => {
+            if let Some(ref callback) = callbacks.service_resolved {
+                callback
+                    .call_async::<()>(lua.create_ser_userdata(LuaServiceInfo(service_info)))
+                    .await?;
+            }
+        }
+        ServiceEvent::ServiceRemoved(service_type, fullname) => {
+            if let Some(ref callback) = callbacks.service_removed {
+                callback.call_async::<()>((service_type, fullname)).await?;
+            }
+        }
+        ServiceEvent::SearchStopped(service_type) => {
+            if let Some(ref callback) = callbacks.search_stopped {
+                callback.call_async::<()>((service_type,)).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn mdns_stop_browse(lua: &Lua, service_type: String) -> LuaResult<()> {
+    let daemon = lua.named_registry_value::<LuaAnyUserData>(MDNS_SERVICE_DAEMON)?;
+    daemon
+        .borrow::<LuaServiceDaemon>()?
+        .0
+        .stop_browse(&service_type)
+        .into_lua_err()?;
+
+    Ok(())
+}
+
+fn mdns_service_info(
+    lua: &Lua,
+    (ty_domain, my_name, host_name, ip, port, properties): (
+        String,
+        String,
+        String,
+        String,
+        u16,
+        Option<HashMap<String, String>>,
+    ),
+) -> LuaResult<LuaAnyUserData> {
+    let service_info = ServiceInfo::new(
+        &ty_domain,
+        &my_name,
+        &host_name,
+        ip,
+        port,
+        properties.unwrap_or_default(),
+    )
+    .into_lua_err()?;
+
+    lua.create_ser_userdata(LuaServiceInfo(service_info))
+}

--- a/src/runtime/regex.rs
+++ b/src/runtime/regex.rs
@@ -1,7 +1,8 @@
 use mlua::prelude::*;
+use regex::Regex;
 
 pub struct LuaRegex {
-    regex: regex::Regex,
+    regex: Regex,
 }
 
 impl LuaRegex {
@@ -18,7 +19,7 @@ pub fn register(lua: &Lua) -> LuaResult<()> {
 }
 
 fn regex_new(_lua: &Lua, pattern: String) -> LuaResult<LuaRegex> {
-    let regex = regex::Regex::new(&pattern).into_lua_err()?;
+    let regex = Regex::new(&pattern).into_lua_err()?;
     Ok(LuaRegex { regex })
 }
 


### PR DESCRIPTION
Add new "mdns" functions:

- mdns.browse(service_type, callbacks) - browse for specific types of mdns services
- mdns.stop_browse(service_type) - halts the browsing for the given type
- mdns.register(mdns.service_info(...)) - register an mdns service

In addition, I understand how create_ser_userdata works now, so both mdns.service_type and a few other existing user datas use this now.